### PR TITLE
Launch apache server automatically on image start

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 Dockerfile to install parentnode and run the kbhff server
 
 Might require sudo:
- - `docker build - < parentNodeDockerFile` to build a docker image
+ - `docker build -t parentnode - < parentNodeDockerFile` to build a docker image
  - `docker images` to view a list of all present images
- - `docker run -i -t IMAGENAME` to connect to a specific image
+ - `docker run -p 80:80 -t parentnode` to connect to the image. You can then connect to the apache server by navigating to `localhost:80` in your browser.
+ - If you want an interactive shell, remove the last `CMD` line from `parentNodeDockerFile`, rebuild the image, and use the `-i` (interactive) flag in the `run` command. You will then have to manually start `apache2` using `service apache2 start`

--- a/parentnodeDockerFile
+++ b/parentnodeDockerFile
@@ -43,3 +43,5 @@ ENV install_webserver_conf Y
 ENV install_email cle@bor.dk
 
 RUN /srv/tools/scripts/install_webserver_configuration-client.sh
+
+CMD service apache2 start && tail -F /var/log/apache2/error.log


### PR DESCRIPTION
The `README` now explains how to forward port 80 to port 80 of the image, and the image automatically starts the `apache2` service when it boots. You don't need to use the `-i` flag anymore.