### PR TITLE
Remove references to /srv/sites/parentnode/janitor

### DIFF
--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -24,8 +24,6 @@ RUN mkdir -p /srv/sites/kbhff/kbhff_dk
 # Clone parentnode
 COPY git/ubuntu_environment/ /srv/tools
 
-COPY git/janitor /srv/sites/parentnode/janitor
-
 #Clone KBHFF:
 COPY git/kbhff_dk /srv/sites/kbhff/kbhff_dk
 RUN chown -R www-data:staff /srv/sites/kbhff/kbhff_dk

--- a/download_and_patch.bash
+++ b/download_and_patch.bash
@@ -5,10 +5,6 @@ if [ ! -f git/kbhff_dk_cleaned.sql ]; then
 	unzip git/kbhff_dk_cleaned.sql.zip -d git
 fi
 
-if [ ! -d git/janitor ]; then
-	git clone https://github.com/parentnode/janitor.git git/janitor
-fi
-
 if [ ! -d git/kbhff_dk ]; then
 	git clone https://github.com/kbhff/kbhff_dk.git git/kbhff_dk
 	pushd git/kbhff_dk

--- a/patches/apply_patches.sh
+++ b/patches/apply_patches.sh
@@ -1,7 +1,5 @@
 patch -r - -N git/kbhff_dk/ci/CodeIgniter-2.2.6/application/config/database.php	< patches/database.php.patch
 patch -r - -N git/ubuntu_environment/conf-client/php-apache2.ini < patches/php-apache2.ini.patch
 patch -r - -N git/ubuntu_environment/conf-client/php-cli.ini < patches/php-cli.ini.patch
-patch -r - -N git/janitor/src/classes/system/cache.class.php < patches/cache.class.php.patch
 patch -r - -N git/kbhff_dk/submodules/janitor/src/classes/system/cache.class.php < patches/cache.class.php.patch
-patch -r - -N git/janitor/src/classes/system/setup.class.php < patches/setup.class.php.patch
 patch -r - -N git/kbhff_dk/submodules/janitor/src/classes/system/setup.class.php < patches/setup.class.php.patch


### PR DESCRIPTION
These references were test commits that shouldn't have been committed to kbhff's master branch, so we don't need to copy the janitor repository to this location.