### PR TITLE
Prevent going through signup flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ You'll need:
  - Before building, run `download_and_patch.bash` to clone the git repositories and patch all the files that need patching for the website to work.
  - Run `sudo docker-compose build` to build the server (currently needs to be done after changing any files). Add the flag `--no-cache` to not use the build cache if necessary.
  - Run `sudo docker-compose up` to start the server.
+ - The very first time you run the server, you should comment out the line `COPY apache/connect_db.php /srv/sites/kbhff/kbhff_dk/theme/config/connect_db.php`; this will allow you to go through the setting up Janitor flow.
 
 You can then go to http://kbhff.local/janitor/admin/setup to set up janitor using the settings below.
 

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:bionic
 MAINTAINER Joshua Hunt <joshua.edward.hunt@gmail.com>
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/apache/Dockerfile
+++ b/apache/Dockerfile
@@ -1,52 +1,65 @@
-FROM ubuntu:18.10
-MAINTAINER Clemens Borys <cle@bor.dk>
+FROM ubuntu:latest
+MAINTAINER Joshua Hunt <joshua.edward.hunt@gmail.com>
 
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Install all the things
-RUN apt-get -qq update \
-    && apt-get -qq upgrade
-RUN apt-get -qq install apt-utils
-RUN apt-get -qq --no-install-recommends install \
-    curl zip logrotate \
-    apache2 apache2-utils ssl-cert \
-    libapache2-mod-php php7.2 php7.2-cli php7.2-common php7.2-curl php7.2-dev php7.2-mbstring \
-	php7.2-zip php7.2-mysql php7.2-xmlrpc php7.2-xml \
-    php-redis php-imagick php-igbinary php-msgpack \
-    ffmpeg \
-    wkhtmltopdf
+RUN apt update -y \
+    && apt upgrade -y \
+	&& apt install -y \
+    	curl \
+		logrotate \
+		zip \
+		apache2 \
+		apache2-utils \
+		ssl-cert \
+		libapache2-mod-php \
+		php7.2 \
+		php7.2-cli \
+		php7.2-common \
+		php7.2-curl \
+		php7.2-dev php7.2-mbstring \
+		php7.2-zip \
+		php7.2-mysql \
+		php7.2-xmlrpc \
+		php7.2-xml \
+		php-redis \
+		php-imagick \
+		php-igbinary \
+		php-msgpack \
+		ffmpeg \
+		wkhtmltopdf
 
 # Make directories
-RUN mkdir -p /srv/sites/apache/logs
-RUN mkdir -p /srv/sites/parentnode
-RUN mkdir -p /srv/sites/kbhff/kbhff_dk
+RUN mkdir -p /srv/sites/apache/logs /srv/sites/parentnode /srv/sites/kbhff/kbhff_dk
 
 # Clone parentnode
 COPY git/ubuntu_environment/ /srv/tools
 
-#Clone KBHFF:
-COPY git/kbhff_dk /srv/sites/kbhff/kbhff_dk
-RUN chown -R www-data:staff /srv/sites/kbhff/kbhff_dk
-
-ENV install_email cle@bor.dk
+ENV install_email joshua.edward.hunt@gmail.com
 
 # Apache2 configuration
 ## Setup our default.conf (points to /srv/sites)
 COPY apache/default.conf /etc/apache2/sites-available/default.conf
 RUN a2ensite default && a2dissite 000-default &&\
-	a2enmod ssl && a2enmod rewrite && a2enmod headers
-
-RUN echo "ServerName ${HOSTNAME}" >> /etc/apache2/apache2.conf
-RUN sed -i "s/webmaster@localhost/${install_email}/;" /etc/apache2/sites-available/default.conf
-RUN cp /srv/tools/conf-client/php-apache2.ini /etc/php/7.2/apache2/php.ini
-RUN cp /srv/tools/conf-client/php-cli.ini /etc/php/7.2/cli/php.ini
+	a2enmod ssl && a2enmod rewrite && a2enmod headers \
+	&& echo "ServerName ${HOSTNAME}" >> /etc/apache2/apache2.conf \
+	&& sed -i "s/webmaster@localhost/${install_email}/;" /etc/apache2/sites-available/default.conf \
+	&& cp /srv/tools/conf-client/php-apache2.ini /etc/php/7.2/apache2/php.ini \
+	&& cp /srv/tools/conf-client/php-cli.ini /etc/php/7.2/cli/php.ini
 
 ## Create virtual host
 
 COPY git/kbhff_dk/apache/httpd-vhosts.conf /etc/apache2/sites-available/kbhff.conf
 RUN a2ensite kbhff
-
 RUN echo "127.0.0.1 kbhff.local" >> /etc/hosts
+
+#Clone KBHFF:
+COPY git/kbhff_dk /srv/sites/kbhff/kbhff_dk
+RUN chown -R www-data:staff /srv/sites/kbhff/kbhff_dk
+RUN mkdir -p /srv/sites/kbhff/kbhff_dk/theme/config
+#This should not be done the first time you set it up...
+COPY apache/connect_db.php /srv/sites/kbhff/kbhff_dk/theme/config/connect_db.php 
 
 EXPOSE 80
 

--- a/apache/connect_db.php
+++ b/apache/connect_db.php
@@ -1,0 +1,17 @@
+<?php
+  
+/**
+* This file contains generel database connection information
+* @package Config
+*/
+define("SITE_DB", "kbhff_dk");
+
+$this->db_connection(
+        array(
+                "host" => "db",
+                "username" => "kbhffdk",
+                "password" => "localpass"
+        )
+);
+
+?>

--- a/download_and_patch.bash
+++ b/download_and_patch.bash
@@ -1,7 +1,7 @@
 mkdir -p git
 
 if [ ! -f git/kbhff_dk_cleaned.sql ]; then
-	wget -nc https://github.com/kbhff/udvikler_kbhff_dk/raw/master/theme/www/assets/kbhff_dk_cleaned.sql.zip -O git/kbhff_dk_cleaned.sql.zip
+	wget -nc https://github.com/kbhff/udvikler_kbhff_dk/blob/master/theme/www/assets/kbhff_dk_cleaned.sql.zip?raw=true
 	unzip git/kbhff_dk_cleaned.sql.zip -d git
 fi
 


### PR DESCRIPTION
 * Prevent being forced to go through the Janitor signup flow every time (it's a bit cumbersome, you have to uncomment a line the first time you run the docker image).
 * Update URL for the kbhff_dk export.
 * Optimise the docker file a little bit.